### PR TITLE
メッセージ種別にSYSTEMを追加

### DIFF
--- a/direct helper.user.js
+++ b/direct helper.user.js
@@ -501,6 +501,7 @@
         FILE: new MessageType("msg-type-file"),
         FILE_AND_TEXT: new MessageType("msg-type-textMultipleFile"),
         STAMP: new MessageType("msg-type-stamp"),
+        SYSTEM: new MessageType("msg-type-system"),
         TEXT: new MessageType("msg-type-text")
     };
 


### PR DESCRIPTION
fix #35 
システムメッセージのメッセージ種別が取得できずにエラーとなっていたため、メッセージ種別にSYSTEMを追加した。
システムメッセージにも、通常のメッセージと同様に投稿日時、ユーザー名、本文が存在するため、現時点ではTEXTと同等の扱いとする。